### PR TITLE
Add prev/next chapter navigation to blog posts

### DIFF
--- a/src/components/PostLayout.astro
+++ b/src/components/PostLayout.astro
@@ -1,4 +1,10 @@
 ---
+interface NavItem {
+  slug: string;
+  title: string;
+  number: string;
+}
+
 interface Props {
   article: {
     meta: {
@@ -6,6 +12,8 @@ interface Props {
       date: Date;
     };
   };
+  prev?: NavItem | null;
+  next?: NavItem | null;
 }
 
 const monthsLong = [
@@ -13,7 +21,7 @@ const monthsLong = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 
-const { article } = Astro.props;
+const { article, prev, next } = Astro.props;
 const d = article.meta.date;
 const formattedDate = `${monthsLong[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
 ---
@@ -57,4 +65,83 @@ const formattedDate = `${monthsLong[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.get
   <div class="prose-mike" data-mdx-content>
     <slot />
   </div>
+
+  {
+    (prev || next) && (
+      <nav
+        aria-label="More chapters"
+        class="mt-20 grid grid-cols-1 border-t border-ink-800 sm:mt-24 sm:grid-cols-2"
+      >
+        {prev ? (
+          <a
+            href={`/posts/${prev.slug}`}
+            class="group flex flex-col gap-3 border-b border-ink-800 py-8 transition-colors hover:bg-ink-900/40 focus-visible:bg-ink-900/40 focus-visible:outline-2 focus-visible:outline-flare-400 focus-visible:outline-offset-[-2px] sm:border-b-0 sm:pr-6"
+          >
+            <span class="small-caps inline-flex items-center gap-2 text-[10px] text-ink-400 transition-colors group-hover:text-flare-400">
+              <svg
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+                class="h-3 w-3 stroke-current"
+              >
+                <path
+                  d="M7.25 11.25 3.75 8m0 0 3.5-3.25M3.75 8h8.5"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              Previous
+              <span class="text-flare-500 group-hover:text-flare-400">·</span>
+              <span class="tabular-nums text-ink-500 group-hover:text-flare-500">
+                {prev.number}
+              </span>
+            </span>
+            <span
+              class="type-architecture text-2xl font-bold text-ink-100 transition-colors group-hover:text-flare-300 sm:text-3xl"
+            >
+              {prev.title}
+            </span>
+          </a>
+        ) : (
+          <div aria-hidden="true" class="hidden sm:block" />
+        )}
+
+        {next ? (
+          <a
+            href={`/posts/${next.slug}`}
+            class="group flex flex-col items-start gap-3 py-8 transition-colors hover:bg-ink-900/40 focus-visible:bg-ink-900/40 focus-visible:outline-2 focus-visible:outline-flare-400 focus-visible:outline-offset-[-2px] sm:items-end sm:pl-6 sm:text-right"
+          >
+            <span class="small-caps inline-flex items-center gap-2 text-[10px] text-ink-400 transition-colors group-hover:text-flare-400">
+              <span class="tabular-nums text-ink-500 group-hover:text-flare-500">
+                {next.number}
+              </span>
+              <span class="text-flare-500 group-hover:text-flare-400">·</span>
+              Next
+              <svg
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+                class="h-3 w-3 stroke-current"
+              >
+                <path
+                  d="M8.75 11.25 12.25 8m0 0-3.5-3.25M12.25 8h-8.5"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
+            <span
+              class="type-architecture text-2xl font-bold text-ink-100 transition-colors group-hover:text-flare-300 sm:text-3xl"
+            >
+              {next.title}
+            </span>
+          </a>
+        ) : (
+          <div aria-hidden="true" class="hidden sm:block" />
+        )}
+      </nav>
+    )
+  }
 </article>

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -5,24 +5,35 @@ import PostLayout from '../../components/PostLayout.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
-  return posts.map((post) => ({
+  const sortedPosts = posts.sort(
+    (a, b) => a.data.meta.date.getTime() - b.data.meta.date.getTime()
+  );
+
+  const toNav = (p: (typeof sortedPosts)[number], i: number) => ({
+    slug: p.id.replace('.md', ''),
+    title: p.data.meta.title,
+    number: String(i + 1).padStart(2, '0'),
+  });
+
+  return sortedPosts.map((post, i) => ({
     params: { slug: post.id.replace('.md', '') },
+    props: {
+      post,
+      prev: i > 0 ? toNav(sortedPosts[i - 1], i - 1) : null,
+      next:
+        i < sortedPosts.length - 1
+          ? toNav(sortedPosts[i + 1], i + 1)
+          : null,
+    },
   }));
 }
 
-const { slug } = Astro.params;
-const posts = await getCollection('posts');
-const post = posts.find(p => p.id.replace('.md', '') === slug);
-
-if (!post) {
-  return Astro.redirect('/404');
-}
-
+const { post, prev, next } = Astro.props;
 const { Content } = await render(post);
 ---
 
 <BaseLayout title={`Mike Cousins - ${post.data.meta.title}`}>
-  <PostLayout article={post.data}>
+  <PostLayout article={post.data} prev={prev} next={next}>
     <Content />
   </PostLayout>
 </BaseLayout>


### PR DESCRIPTION
## What

Adds a chapter-to-chapter navigation block at the bottom of every blog post, linking to the previous and next chapters in chronological order.

## Why

The Cancer Journey is sequential — the index calls it "a diary in the order it happened" and numbers chapters 01–62. But once a reader landed on a post, the only way to keep reading in order was to bounce back to `/posts` and find the next entry. This adds direct neighbor links so the journey reads end-to-end.

## How

- **`src/pages/posts/[slug].astro`** — sorts posts ascending by date inside `getStaticPaths` and passes `prev`/`next` props per page, so the sort/lookup happens once at build time rather than every render.
- **`src/components/PostLayout.astro`** — renders an `aria-label`ed `<nav>` block when at least one neighbor exists.

## Design notes

The nav fits the existing editorial language rather than introducing new patterns:

- **Chronological framing** ("Previous · 18" / "20 · Next") reusing the same `01`–`62` numbering as the index — not "newer/older".
- **Small-caps labels** in `ink-400` with the flare-orange `·` separator, transitioning to `flare-400` on hover, mirroring the existing "Back to the journey" link.
- **Arrow icons** are the same 16×16 SVG paths as the back link; the right-pointer is a mirrored path so stroke weights match exactly.
- **Titles** in `type-architecture font-bold` at `text-2xl sm:text-3xl` — punchy enough to read as real targets but subordinate to the article h1.
- **Layout**: two-column grid on `sm+` with prev left-anchored and next right-anchored (they "open outward"); stacks on mobile with a single divider between cells.
- **Edge cases**: when the first or last post is missing a neighbor, an invisible spacer cell holds the column on desktop so the remaining link stays in its natural side; the spacer drops out on mobile via `hidden sm:block`.

## Verified

Browser-checked locally on three states:

- `bone-marrow-biopsy` (#19) — both prev (#18 Lymph Node Biopsy) and next (#20 PET Scan)
- `a-lump` (#1) — only next, right-anchored
- `5-years-cured` (#62) — only prev, left-anchored
- Mobile viewport — cells stack with a divider, no orphan spacers

No console or server errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)